### PR TITLE
Added editor to blog posts allowing image uploading. Fixes #42

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -38,6 +38,8 @@ THIRD_PARTY_APPS = (
     'allauth.socialaccount',  # registration
     'stdimage',
     'rest_framework',
+    'ckeditor',
+    'ckeditor_uploader'
 )
 
 # Apps specific for this project go here.
@@ -320,3 +322,6 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 50
 }
+
+CKEDITOR_UPLOAD_PATH = 'uploads/'
+CKEDITOR_IMAGE_BACKEND = 'pillow'

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -36,6 +36,9 @@ THIRD_PARTY_APPS = (
     'allauth',  # registration
     'allauth.account',  # registration
     'allauth.socialaccount',  # registration
+    'allauth.socialaccount.providers.google',  # registration
+    'allauth.socialaccount.providers.github',  # registration
+    'allauth.socialaccount.providers.facebook',  # registration
     'stdimage',
     'rest_framework',
     'ckeditor',
@@ -242,6 +245,7 @@ ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 ACCOUNT_ALLOW_REGISTRATION = env.bool('DJANGO_ACCOUNT_ALLOW_REGISTRATION', True)
 ACCOUNT_ADAPTER = 'mhackspace.users.adapters.AccountAdapter'
 SOCIALACCOUNT_ADAPTER = 'mhackspace.users.adapters.SocialAccountAdapter'
+SOCIALACCOUNT_QUERY_EMAIL = True
 
 # Custom user app defaults
 # Select the correct user model

--- a/config/urls.py
+++ b/config/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
 
     # Django Admin, use {% url 'admin:index' %}
     url(r'{}'.format(settings.ADMIN_URL), admin.site.urls),
+    url(r'^ckeditor/', include('ckeditor_uploader.urls')),
 
     # User management
     url(r'^users/', include('mhackspace.users.urls', namespace='users')),

--- a/mhackspace/blog/models.py
+++ b/mhackspace/blog/models.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from mhackspace.users.models import User
 from stdimage.models import StdImageField
 from stdimage.utils import UploadToAutoSlugClassNameDir
+from ckeditor_uploader.fields import RichTextUploadingField
 
 
 class Category(models.Model):
@@ -34,7 +35,7 @@ class Post(models.Model):
                 "height": 220,
                 "crop": True}})
 
-    description = models.TextField()
+    description = RichTextUploadingField()
     published_date = models.DateTimeField(default=timezone.now)
     updated_date = models.DateTimeField(default=timezone.now)
     active = models.BooleanField(default=True)

--- a/mhackspace/templates/blog/posts.html
+++ b/mhackspace/templates/blog/posts.html
@@ -8,7 +8,7 @@
     {% for post in posts %}
     <a href="{{ post.get_absolute_url }}"><h1>{{ post.title }}</h1></a>
     <p>Published: {{ post.published_date }}</p>
-    <p>{{ post.description }}</p>
+    <p>{{ post.description|safe }}</p>
     {% endfor %}
 
     {% if posts.num_pages > 1 %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -62,3 +62,4 @@ git+https://github.com/olymk2/scaffold.git
 djangorestframework==3.5.4
 django-filter==1.0.1
 
+django-ckeditor


### PR DESCRIPTION
This adds in in the ckeditor to the post description box allowing images to be uploaded and custom HTML to be used in blog posts. I do understand that could be a problem allowing people to upload images and use whatever HTML they would like but I assume this would only be used by admins.

Here are a few screenshots of what it currently looks like.

![screenshot from 2017-02-26 16-40-33](https://cloud.githubusercontent.com/assets/8594759/23341619/df790944-fc42-11e6-8540-f22717868779.png)
![screenshot from 2017-02-26 16-40-06](https://cloud.githubusercontent.com/assets/8594759/23341618/df77bf26-fc42-11e6-8eaa-ef517d35ae20.png)
